### PR TITLE
升级到最新的iflux2 需要额外的react-dom, 这个并不真的是react-dom,是一个shim，目的保证每次的re-rende…

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest",
-    "preinstall": "npm install ./react-dom"
+    "postinstall": "npm install ./react-dom"
   },
   "dependencies": {
     "iflux2": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
-    "test": "jest"
+    "test": "jest",
+    "preinstall": "npm install ./react-dom"
   },
   "dependencies": {
-    "iflux2": "^1.2.1",
+    "iflux2": "1.2.6",
     "react": "15.3.2",
     "react-native": "0.36.0"
   },

--- a/react-dom/index.js
+++ b/react-dom/index.js
@@ -1,0 +1,5 @@
+import {unstable_batchedUpdates} from 'react-native';
+
+export {
+  unstable_batchedUpdates
+};

--- a/react-dom/package.json
+++ b/react-dom/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "react-dom",
+  "version": "1.0.0",
+  "description": "mock react-dom in react-native",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": ["react-native", "react-dom"],
+  "author": "",
+  "license": "BSD"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,6 +376,10 @@ babel-plugin-syntax-class-properties@^6.5.0, babel-plugin-syntax-class-propertie
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
+babel-plugin-syntax-decorators@^6.1.18:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+
 babel-plugin-syntax-flow@^6.18.0, babel-plugin-syntax-flow@^6.5.0, babel-plugin-syntax-flow@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
@@ -399,6 +403,14 @@ babel-plugin-transform-class-properties@^6.5.0, babel-plugin-transform-class-pro
     babel-helper-function-name "^6.18.0"
     babel-plugin-syntax-class-properties "^6.8.0"
     babel-runtime "^6.9.1"
+
+babel-plugin-transform-decorators-legacy@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.4.tgz#741b58f6c5bce9e6027e0882d9c994f04f366925"
+  dependencies:
+    babel-plugin-syntax-decorators "^6.1.18"
+    babel-runtime "^6.2.0"
+    babel-template "^6.3.0"
 
 babel-plugin-transform-es2015-arrow-functions@^6.5.0, babel-plugin-transform-es2015-arrow-functions@^6.5.2, babel-plugin-transform-es2015-arrow-functions@^6.8.0:
   version "6.8.0"
@@ -736,14 +748,14 @@ babel-register@^6.18.0, babel-register@^6.6.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
+babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.2.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.18.0.tgz#0f4177ffd98492ef13b9f823e9994a02584c9078"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.9.5"
 
-babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.8.0:
+babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.3.0, babel-template@^6.8.0:
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.16.0.tgz#e149dd1a9f03a35f817ddbc4d0481988e7ebc8ca"
   dependencies:
@@ -2256,9 +2268,9 @@ iconv-lite@0.4.11:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.11.tgz#2ecb42fd294744922209a2e7c404dac8793d8ade"
 
-iflux2@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/iflux2/-/iflux2-1.2.1.tgz#c8551063ff0b65c1c78f5ac30c8f4cea070f882e"
+iflux2@1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/iflux2/-/iflux2-1.2.6.tgz#afdb4e95539f8ccb904df99e519fdc8d525e19f4"
   dependencies:
     events "^1.1.0"
     immutable "^3.8.1"


### PR DESCRIPTION
升级到最新的iflux2 需要额外的react-dom, 这个并不真的是react-dom,是一个shim，目的保证每次的re-rende…都是精确的，不会震荡

另外，在yarn或者npm install之后，确认node_module下面有没有把react-dom拷贝过去，如果没有再执行一次yarn或者npm install就好了。待我详细研究下为什么会这样。